### PR TITLE
query select removed string conversion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/goatquery/goatquery-go
+module github.com/asadasafish/goatquery-go
 
 go 1.20
 

--- a/response.go
+++ b/response.go
@@ -33,11 +33,11 @@ func BuildPagedResponse[T any](res []T, query Query, totalCount *int64) PagedRes
 			})
 			name := field.Tag.Get("json")
 
+			// '-' in the json tag means to not return that property
 			if name != "" && name != "-" {
-				// '-' in the json tag means to not return that property
 				newObj[name] = v.FieldByNameFunc(func(p string) bool {
 					return strings.EqualFold(property, p)
-				}).String()
+				})
 			}
 		}
 


### PR DESCRIPTION
Converted to a string before which removed functionality.